### PR TITLE
ci: use production workflows ref

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   release:
-    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@ci-release-token-runner-stable
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@dev/v1/v1.2
     with:
       publish-aws-ci: false
       publish-aws-user: false

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   try:
-    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@ci-release-token-runner-stable
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@dev/v1/v1.2
     with:
       enable-macos: false
       enable-windows: false


### PR DESCRIPTION
## Summary
- point release verify/new-version callers at workflows dev/v1/v1.2 instead of the temporary self-hosted test branch

## Verification
- ruby YAML parser for changed workflows
- git diff --check
- pre-commit yarn format && yarn dist