### PR TITLE
Prerelease v3.1.35-alpha.3

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   release:
-    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@ci-release-token-runner-stable
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@dev/v1/v1.2
     with:
       publish-aws-ci: false
       publish-aws-user: false

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -17,6 +17,7 @@ jobs:
     with:
       enable-macos: false
       enable-windows: false
+      build-container-enabled: false
       prebuild: true
       publish-versioning: false
       publish-aws-ci: false

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   try:
-    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@ci-release-token-runner-stable
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@dev/v1/v1.2
     with:
       enable-macos: false
       enable-windows: false

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -18,6 +18,7 @@ jobs:
       enable-macos: false
       enable-windows: false
       build-container-enabled: false
+      setup-python-enabled: false
       prebuild: true
       publish-versioning: false
       publish-aws-ci: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-trader/action-bump-version",
-  "version": "3.1.35-alpha.2",
+  "version": "3.1.35-alpha.3",
   "type": "module",
   "main": "dist/index.js",
   "repository": "https://github.com/kungfu-trader/action-bump-version",


### PR DESCRIPTION
## Summary
- validate action-bump-version against the production workflows ref after moving off the temporary self-hosted test branch

## Verification target
- release verify should use kungfu-systems/workflows@dev/v1/v1.2
- Linux prebuild should continue using the configured self-hosted runner labels
- merge should trigger release-new-version through the same production workflows ref