### PR TITLE
ci: use local linux release verify build

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -17,6 +17,7 @@ jobs:
     with:
       enable-macos: false
       enable-windows: false
+      build-container-enabled: false
       prebuild: true
       publish-versioning: false
       publish-aws-ci: false


### PR DESCRIPTION
## Summary
- pass build-container-enabled: false so the ABV self-hosted verify test uses the workflows local Linux path instead of pulling the heavy builder container

## Verification
- ruby YAML parser
- git diff --check
- pre-commit yarn format && yarn dist