### PR TITLE
ci: skip python setup in release verify smoke

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -18,6 +18,7 @@ jobs:
       enable-macos: false
       enable-windows: false
       build-container-enabled: false
+      setup-python-enabled: false
       prebuild: true
       publish-versioning: false
       publish-aws-ci: false


### PR DESCRIPTION
## Summary
- pass setup-python-enabled: false for the ABV release verify smoke path

## Verification
- ruby YAML parser
- git diff --check
- pre-commit yarn format && yarn dist