### PR TITLE
chore: advance dev version after alpha.3 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-trader/action-bump-version",
-  "version": "3.1.35-alpha.3",
+  "version": "3.1.35-alpha.4",
   "type": "module",
   "main": "dist/index.js",
   "repository": "https://github.com/kungfu-trader/action-bump-version",


### PR DESCRIPTION
## Summary\n- advance the dev branch package version to 3.1.35-alpha.4\n- match the dev-advance commit generated by the failed alpha.3 release run\n\n## Validation\n- git diff --check\n- identity guard check\n\n## Notes\n- no build needed; this only updates the package version after the alpha.3 tag was already published