### PR TITLE
fix: skip protected release branch push

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Inputs that control protection:
 | `no-protection` | `false` | Set to `true` to skip branch protection changes. |
 | `protect-dev-branches` | `false` | Set to `true` to restrict direct pushes to `dev/*/*`. |
 | `reset-default-branch` | `true` | Set to `false` when a reusable workflow must not rewrite the repository default branch. |
+| `skip-base-branch-push` | `false` | Set to `true` when a protected release branch is already updated by PR merge and must not be force-pushed during `postbuild`. |
 
 `reset-default-branch=false` is used by the shared release workflow when it runs
 inside a caller repository. It prevents a reusable workflow from changing the
@@ -291,6 +292,7 @@ Custom build flow:
 | `no-protection` | No | `false` | Set to `true` to skip branch protection changes. |
 | `protect-dev-branches` | No | `false` | Set to `true` to restrict direct pushes to `dev/*/*`. |
 | `reset-default-branch` | No | `true` | Set to `false` to skip default-branch reset during merge finalization. |
+| `skip-base-branch-push` | No | `false` | Set to `true` to skip direct `postbuild` pushes to the merged PR base branch. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   reset-default-branch:
     description: "Choices [true/false]"
     default: "true"
+  skip-base-branch-push:
+    description: "Choices [true/false]"
+    default: "false"
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -39381,7 +39381,11 @@ async function mergeCall(argv, keyword) {
       // Push release tag
       await gitCall('push', '-f', 'origin', `HEAD:refs/tags/v${version}`);
       // Push release commit
-      await gitCall('push', '-f', 'origin', `HEAD:refs/heads/${argv.baseRef}`);
+      if (argv.skipBaseBranchPush) {
+        console.log(`> skip pushing release commit to protected base branch ${argv.baseRef}`);
+      } else {
+        await gitCall('push', '-f', 'origin', `HEAD:refs/heads/${argv.baseRef}`);
+      }
       // Prepare new prerelease version for alpha channel
       await bumpCall(argv, 'prerelease');
       await pushAlphaVersionTag(getCurrentVersion(argv.cwd));
@@ -42648,6 +42652,7 @@ const main = async function () {
     protection: getInput('no-protection') === 'false',
     protectDevBranches: getInput('protect-dev-branches') === 'true',
     resetDefaultBranch: getInput('reset-default-branch') !== 'false',
+    skipBaseBranchPush: getInput('skip-base-branch-push') === 'true',
     commitId: context.sha,
     headRef: headRef,
     baseRef: baseRef,

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ const main = async function () {
     protection: core.getInput('no-protection') === 'false',
     protectDevBranches: core.getInput('protect-dev-branches') === 'true',
     resetDefaultBranch: core.getInput('reset-default-branch') !== 'false',
+    skipBaseBranchPush: core.getInput('skip-base-branch-push') === 'true',
     commitId: context.sha,
     headRef: headRef,
     baseRef: baseRef,

--- a/lib.js
+++ b/lib.js
@@ -342,7 +342,11 @@ async function mergeCall(argv, keyword) {
       // Push release tag
       await gitCall('push', '-f', 'origin', `HEAD:refs/tags/v${version}`);
       // Push release commit
-      await gitCall('push', '-f', 'origin', `HEAD:refs/heads/${argv.baseRef}`);
+      if (argv.skipBaseBranchPush) {
+        console.log(`> skip pushing release commit to protected base branch ${argv.baseRef}`);
+      } else {
+        await gitCall('push', '-f', 'origin', `HEAD:refs/heads/${argv.baseRef}`);
+      }
       // Prepare new prerelease version for alpha channel
       await bumpCall(argv, 'prerelease');
       await pushAlphaVersionTag(getCurrentVersion(argv.cwd));


### PR DESCRIPTION
## Summary

Add `skip-base-branch-push` for postbuild so protected release branches updated by PR merge do not get force-pushed by the action.

This fixes the v4/v2 stable release failure where tags were created, but the follow-up direct push to `release/*/*` was rejected by branch protection.

## Validation

- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`
