### PR TITLE
Release v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ resolution, admin enforcement, and no force pushes or deletions. `dev/*/*` keeps
 status-check protection but does not require review or push restriction unless
 `protect-dev-branches` is enabled.
 
+Before creating a version tag, `prebuild` deletes only the matching local tag if
+it already exists. This keeps persistent self-hosted runner workspaces from
+failing on stale local tags while leaving remote tags untouched until `postbuild`
+publishes the intended refs.
+
 Inputs that control protection:
 
 | Input | Default | Meaning |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Inputs that control protection:
 | `no-protection` | `false` | Set to `true` to skip branch protection changes. |
 | `protect-dev-branches` | `false` | Set to `true` to restrict direct pushes to `dev/*/*`. |
 | `reset-default-branch` | `true` | Set to `false` when a reusable workflow must not rewrite the repository default branch. |
+| `skip-base-branch-push` | `false` | Set to `true` when a protected release branch is already updated by PR merge and must not be force-pushed during `postbuild`. |
 
 `reset-default-branch=false` is used by the shared release workflow when it runs
 inside a caller repository. It prevents a reusable workflow from changing the
@@ -291,6 +292,7 @@ Custom build flow:
 | `no-protection` | No | `false` | Set to `true` to skip branch protection changes. |
 | `protect-dev-branches` | No | `false` | Set to `true` to restrict direct pushes to `dev/*/*`. |
 | `reset-default-branch` | No | `true` | Set to `false` to skip default-branch reset during merge finalization. |
+| `skip-base-branch-push` | No | `false` | Set to `true` to skip direct `postbuild` pushes to the merged PR base branch. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   reset-default-branch:
     description: "Choices [true/false]"
     default: "true"
+  skip-base-branch-push:
+    description: "Choices [true/false]"
+    default: "false"
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -39381,7 +39381,11 @@ async function mergeCall(argv, keyword) {
       // Push release tag
       await gitCall('push', '-f', 'origin', `HEAD:refs/tags/v${version}`);
       // Push release commit
-      await gitCall('push', '-f', 'origin', `HEAD:refs/heads/${argv.baseRef}`);
+      if (argv.skipBaseBranchPush) {
+        console.log(`> skip pushing release commit to protected base branch ${argv.baseRef}`);
+      } else {
+        await gitCall('push', '-f', 'origin', `HEAD:refs/heads/${argv.baseRef}`);
+      }
       // Prepare new prerelease version for alpha channel
       await bumpCall(argv, 'prerelease');
       await pushAlphaVersionTag(getCurrentVersion(argv.cwd));
@@ -42648,6 +42652,7 @@ const main = async function () {
     protection: getInput('no-protection') === 'false',
     protectDevBranches: getInput('protect-dev-branches') === 'true',
     resetDefaultBranch: getInput('reset-default-branch') !== 'false',
+    skipBaseBranchPush: getInput('skip-base-branch-push') === 'true',
     commitId: context.sha,
     headRef: headRef,
     baseRef: baseRef,

--- a/dist/index.js
+++ b/dist/index.js
@@ -39157,6 +39157,19 @@ async function gitCall(...args) {
   console.log(output);
 }
 
+async function deleteLocalTagIfExists(tag) {
+  if (bumpOpts.dry) {
+    console.log(`$ git tag -d ${tag} # if local tag exists`);
+    return;
+  }
+  try {
+    await git_client('rev-parse', '--verify', `refs/tags/${tag}`);
+  } catch {
+    return;
+  }
+  await gitCall('tag', '-d', tag);
+}
+
 async function octokitGraphqlCall(argv, query) {
   const octokit = getOctokit(argv.token);
   const result = await octokit.graphql(query, {
@@ -39173,6 +39186,10 @@ async function bumpCall(argv, keyword, message, tag = true) {
   const nonReleaseMessageOpt = ['--message', message ? `"${message}"` : `"Move on to v${nextVersion}"`];
   const messageOpt = keyword === 'patch' ? [] : nonReleaseMessageOpt;
   const tagOpt = tag ? [] : ['--no-git-tag-version'];
+
+  if (tag) {
+    await deleteLocalTagIfExists(`v${nextVersion}`);
+  }
 
   if (hasLerna(argv.cwd)) {
     if (keyword === 'patch' || keyword === 'prepatch') {

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ const main = async function () {
     protection: core.getInput('no-protection') === 'false',
     protectDevBranches: core.getInput('protect-dev-branches') === 'true',
     resetDefaultBranch: core.getInput('reset-default-branch') !== 'false',
+    skipBaseBranchPush: core.getInput('skip-base-branch-push') === 'true',
     commitId: context.sha,
     headRef: headRef,
     baseRef: baseRef,

--- a/lib.js
+++ b/lib.js
@@ -118,6 +118,19 @@ async function gitCall(...args) {
   console.log(output);
 }
 
+async function deleteLocalTagIfExists(tag) {
+  if (bumpOpts.dry) {
+    console.log(`$ git tag -d ${tag} # if local tag exists`);
+    return;
+  }
+  try {
+    await git('rev-parse', '--verify', `refs/tags/${tag}`);
+  } catch {
+    return;
+  }
+  await gitCall('tag', '-d', tag);
+}
+
 async function octokitGraphqlCall(argv, query) {
   const octokit = github.getOctokit(argv.token);
   const result = await octokit.graphql(query, {
@@ -134,6 +147,10 @@ async function bumpCall(argv, keyword, message, tag = true) {
   const nonReleaseMessageOpt = ['--message', message ? `"${message}"` : `"Move on to v${nextVersion}"`];
   const messageOpt = keyword === 'patch' ? [] : nonReleaseMessageOpt;
   const tagOpt = tag ? [] : ['--no-git-tag-version'];
+
+  if (tag) {
+    await deleteLocalTagIfExists(`v${nextVersion}`);
+  }
 
   if (hasLerna(argv.cwd)) {
     if (keyword === 'patch' || keyword === 'prepatch') {

--- a/lib.js
+++ b/lib.js
@@ -342,7 +342,11 @@ async function mergeCall(argv, keyword) {
       // Push release tag
       await gitCall('push', '-f', 'origin', `HEAD:refs/tags/v${version}`);
       // Push release commit
-      await gitCall('push', '-f', 'origin', `HEAD:refs/heads/${argv.baseRef}`);
+      if (argv.skipBaseBranchPush) {
+        console.log(`> skip pushing release commit to protected base branch ${argv.baseRef}`);
+      } else {
+        await gitCall('push', '-f', 'origin', `HEAD:refs/heads/${argv.baseRef}`);
+      }
       // Prepare new prerelease version for alpha channel
       await bumpCall(argv, 'prerelease');
       await pushAlphaVersionTag(getCurrentVersion(argv.cwd));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-systems/action-bump-version",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "type": "module",
   "main": "dist/index.js",
   "repository": "https://github.com/kungfu-systems/action-bump-version",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-systems/action-bump-version",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "repository": "https://github.com/kungfu-systems/action-bump-version",


### PR DESCRIPTION
## Summary

Retry the v4.0.0 stable promotion with the protected release branch postbuild fix included.

The previous stable run created tags but failed when postbuild tried to force-push the protected release branch. This release branch now includes `skip-base-branch-push`, so postbuild should publish tags without directly pushing `release/*/*`.

## Validation

- Alpha fix PR #514 passed release-verify and merged
- Alpha release run `28326836594` succeeded
