### PR TITLE
fix: ignore stale local version tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ resolution, admin enforcement, and no force pushes or deletions. `dev/*/*` keeps
 status-check protection but does not require review or push restriction unless
 `protect-dev-branches` is enabled.
 
+Before creating a version tag, `prebuild` deletes only the matching local tag if
+it already exists. This keeps persistent self-hosted runner workspaces from
+failing on stale local tags while leaving remote tags untouched until `postbuild`
+publishes the intended refs.
+
 Inputs that control protection:
 
 | Input | Default | Meaning |

--- a/dist/index.js
+++ b/dist/index.js
@@ -39157,6 +39157,19 @@ async function gitCall(...args) {
   console.log(output);
 }
 
+async function deleteLocalTagIfExists(tag) {
+  if (bumpOpts.dry) {
+    console.log(`$ git tag -d ${tag} # if local tag exists`);
+    return;
+  }
+  try {
+    await git_client('rev-parse', '--verify', `refs/tags/${tag}`);
+  } catch {
+    return;
+  }
+  await gitCall('tag', '-d', tag);
+}
+
 async function octokitGraphqlCall(argv, query) {
   const octokit = getOctokit(argv.token);
   const result = await octokit.graphql(query, {
@@ -39173,6 +39186,10 @@ async function bumpCall(argv, keyword, message, tag = true) {
   const nonReleaseMessageOpt = ['--message', message ? `"${message}"` : `"Move on to v${nextVersion}"`];
   const messageOpt = keyword === 'patch' ? [] : nonReleaseMessageOpt;
   const tagOpt = tag ? [] : ['--no-git-tag-version'];
+
+  if (tag) {
+    await deleteLocalTagIfExists(`v${nextVersion}`);
+  }
 
   if (hasLerna(argv.cwd)) {
     if (keyword === 'patch' || keyword === 'prepatch') {

--- a/lib.js
+++ b/lib.js
@@ -118,6 +118,19 @@ async function gitCall(...args) {
   console.log(output);
 }
 
+async function deleteLocalTagIfExists(tag) {
+  if (bumpOpts.dry) {
+    console.log(`$ git tag -d ${tag} # if local tag exists`);
+    return;
+  }
+  try {
+    await git('rev-parse', '--verify', `refs/tags/${tag}`);
+  } catch {
+    return;
+  }
+  await gitCall('tag', '-d', tag);
+}
+
 async function octokitGraphqlCall(argv, query) {
   const octokit = github.getOctokit(argv.token);
   const result = await octokit.graphql(query, {
@@ -134,6 +147,10 @@ async function bumpCall(argv, keyword, message, tag = true) {
   const nonReleaseMessageOpt = ['--message', message ? `"${message}"` : `"Move on to v${nextVersion}"`];
   const messageOpt = keyword === 'patch' ? [] : nonReleaseMessageOpt;
   const tagOpt = tag ? [] : ['--no-git-tag-version'];
+
+  if (tag) {
+    await deleteLocalTagIfExists(`v${nextVersion}`);
+  }
 
   if (hasLerna(argv.cwd)) {
     if (keyword === 'patch' || keyword === 'prepatch') {


### PR DESCRIPTION
## Summary

Delete the matching local version tag before `prebuild` invokes `yarn version` or `lerna version`.

Self-hosted runner checkouts can retain local tags across jobs. A retry of the same stable version should not fail before verification just because a local tag remains from a previous run. This only removes local tags and does not delete remote tags.

## Validation

- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`
