### PR TITLE
Prerelease v4.0.0-alpha.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ resolution, admin enforcement, and no force pushes or deletions. `dev/*/*` keeps
 status-check protection but does not require review or push restriction unless
 `protect-dev-branches` is enabled.
 
+Before creating a version tag, `prebuild` deletes only the matching local tag if
+it already exists. This keeps persistent self-hosted runner workspaces from
+failing on stale local tags while leaving remote tags untouched until `postbuild`
+publishes the intended refs.
+
 Inputs that control protection:
 
 | Input | Default | Meaning |

--- a/dist/index.js
+++ b/dist/index.js
@@ -39157,6 +39157,19 @@ async function gitCall(...args) {
   console.log(output);
 }
 
+async function deleteLocalTagIfExists(tag) {
+  if (bumpOpts.dry) {
+    console.log(`$ git tag -d ${tag} # if local tag exists`);
+    return;
+  }
+  try {
+    await git_client('rev-parse', '--verify', `refs/tags/${tag}`);
+  } catch {
+    return;
+  }
+  await gitCall('tag', '-d', tag);
+}
+
 async function octokitGraphqlCall(argv, query) {
   const octokit = getOctokit(argv.token);
   const result = await octokit.graphql(query, {
@@ -39173,6 +39186,10 @@ async function bumpCall(argv, keyword, message, tag = true) {
   const nonReleaseMessageOpt = ['--message', message ? `"${message}"` : `"Move on to v${nextVersion}"`];
   const messageOpt = keyword === 'patch' ? [] : nonReleaseMessageOpt;
   const tagOpt = tag ? [] : ['--no-git-tag-version'];
+
+  if (tag) {
+    await deleteLocalTagIfExists(`v${nextVersion}`);
+  }
 
   if (hasLerna(argv.cwd)) {
     if (keyword === 'patch' || keyword === 'prepatch') {

--- a/lib.js
+++ b/lib.js
@@ -118,6 +118,19 @@ async function gitCall(...args) {
   console.log(output);
 }
 
+async function deleteLocalTagIfExists(tag) {
+  if (bumpOpts.dry) {
+    console.log(`$ git tag -d ${tag} # if local tag exists`);
+    return;
+  }
+  try {
+    await git('rev-parse', '--verify', `refs/tags/${tag}`);
+  } catch {
+    return;
+  }
+  await gitCall('tag', '-d', tag);
+}
+
 async function octokitGraphqlCall(argv, query) {
   const octokit = github.getOctokit(argv.token);
   const result = await octokit.graphql(query, {
@@ -134,6 +147,10 @@ async function bumpCall(argv, keyword, message, tag = true) {
   const nonReleaseMessageOpt = ['--message', message ? `"${message}"` : `"Move on to v${nextVersion}"`];
   const messageOpt = keyword === 'patch' ? [] : nonReleaseMessageOpt;
   const tagOpt = tag ? [] : ['--no-git-tag-version'];
+
+  if (tag) {
+    await deleteLocalTagIfExists(`v${nextVersion}`);
+  }
 
   if (hasLerna(argv.cwd)) {
     if (keyword === 'patch' || keyword === 'prepatch') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-systems/action-bump-version",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "type": "module",
   "main": "dist/index.js",
   "repository": "https://github.com/kungfu-systems/action-bump-version",


### PR DESCRIPTION
## Summary

Prerelease the stale-local-tag fix for action-bump-version v4.

Self-hosted runner workspaces can retain local version tags across jobs; prebuild now deletes only the matching local tag before creating it again.

## Validation

- Fix PR #516 local checks passed before merge
