### PR TITLE
Release v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Inputs that control protection:
 | `protect-dev-branches` | `false` | Set to `true` to restrict direct pushes to `dev/*/*`. |
 | `reset-default-branch` | `true` | Set to `false` when a reusable workflow must not rewrite the repository default branch. |
 | `skip-base-branch-push` | `false` | Set to `true` when a protected release branch is already updated by PR merge and must not be force-pushed during `postbuild`. |
+| `skip-channel-branch-merge` | `false` | Set to `true` when protected channel branches such as `alpha/*/*` must not be updated directly by `postbuild`. |
 
 `reset-default-branch=false` is used by the shared release workflow when it runs
 inside a caller repository. It prevents a reusable workflow from changing the
@@ -298,6 +299,7 @@ Custom build flow:
 | `protect-dev-branches` | No | `false` | Set to `true` to restrict direct pushes to `dev/*/*`. |
 | `reset-default-branch` | No | `true` | Set to `false` to skip default-branch reset during merge finalization. |
 | `skip-base-branch-push` | No | `false` | Set to `true` to skip direct `postbuild` pushes to the merged PR base branch. |
+| `skip-channel-branch-merge` | No | `false` | Set to `true` to skip direct `postbuild` merges into protected release/alpha/dev channel branches. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   skip-base-branch-push:
     description: "Choices [true/false]"
     default: "false"
+  skip-channel-branch-merge:
+    description: "Choices [true/false]"
+    default: "false"
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -39466,8 +39466,12 @@ async function mergeCall(argv, keyword) {
   const versionRef = `v${currentVersion.major}/v${currentVersion.major}.${currentVersion.minor}`;
 
   console.log(`${external_node_os_namespaceObject.EOL}# https://docs.github.com/en/rest/reference/repos#merge-a-branch${external_node_os_namespaceObject.EOL}`);
-  for (const channel of mergeTargets[keyword]) {
-    await mergeRemoteChannel(`${channel}/${versionRef}`);
+  if (argv.skipChannelBranchMerge) {
+    console.log(`> skip merging version tag into protected channel branches: ${mergeTargets[keyword].join(', ')}`);
+  } else {
+    for (const channel of mergeTargets[keyword]) {
+      await mergeRemoteChannel(`${channel}/${versionRef}`);
+    }
   }
 
   if (keyword === 'patch') {
@@ -42670,6 +42674,7 @@ const main = async function () {
     protectDevBranches: getInput('protect-dev-branches') === 'true',
     resetDefaultBranch: getInput('reset-default-branch') !== 'false',
     skipBaseBranchPush: getInput('skip-base-branch-push') === 'true',
+    skipChannelBranchMerge: getInput('skip-channel-branch-merge') === 'true',
     commitId: context.sha,
     headRef: headRef,
     baseRef: baseRef,

--- a/index.js
+++ b/index.js
@@ -128,6 +128,7 @@ const main = async function () {
     protectDevBranches: core.getInput('protect-dev-branches') === 'true',
     resetDefaultBranch: core.getInput('reset-default-branch') !== 'false',
     skipBaseBranchPush: core.getInput('skip-base-branch-push') === 'true',
+    skipChannelBranchMerge: core.getInput('skip-channel-branch-merge') === 'true',
     commitId: context.sha,
     headRef: headRef,
     baseRef: baseRef,

--- a/lib.js
+++ b/lib.js
@@ -427,8 +427,12 @@ async function mergeCall(argv, keyword) {
   const versionRef = `v${currentVersion.major}/v${currentVersion.major}.${currentVersion.minor}`;
 
   console.log(`${os.EOL}# https://docs.github.com/en/rest/reference/repos#merge-a-branch${os.EOL}`);
-  for (const channel of mergeTargets[keyword]) {
-    await mergeRemoteChannel(`${channel}/${versionRef}`);
+  if (argv.skipChannelBranchMerge) {
+    console.log(`> skip merging version tag into protected channel branches: ${mergeTargets[keyword].join(', ')}`);
+  } else {
+    for (const channel of mergeTargets[keyword]) {
+      await mergeRemoteChannel(`${channel}/${versionRef}`);
+    }
   }
 
   if (keyword === 'patch') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-systems/action-bump-version",
-  "version": "4.0.0-alpha.2",
+  "version": "4.0.0-alpha.3",
   "type": "module",
   "main": "dist/index.js",
   "repository": "https://github.com/kungfu-systems/action-bump-version",


### PR DESCRIPTION
## Summary

Retry the v4.0.0 stable promotion with the protected-branch release fixes included.

This alpha includes:

- skip direct release branch push during postbuild
- ignore stale local version tags on persistent runners
- skip direct channel branch merges during postbuild

## Validation

- Alpha release run `28327360473` succeeded
