### PR TITLE
Use stable workflow refs for v4 release workflows

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -15,8 +15,8 @@ permissions:
 
 jobs:
   release:
-    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@v2
     with:
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: dev/v4/v4.0
+      action-bump-version-ref: v4

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   try:
-    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@v2
     with:
       enable-macos: false
       enable-windows: false
@@ -23,7 +23,7 @@ jobs:
       publish-versioning: false
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: dev/v4/v4.0
+      action-bump-version-ref: v4
       build-runner-linux-labels: '["self-hosted","Linux","X64","agent-120","kungfu-build","linux-x64"]'
   
   verify:


### PR DESCRIPTION
## Summary\n- use workflows@v2 for v4 release and verify workflows\n- use action-bump-version@v4 for self bootstrap\n- remove v2.0-alpha and dev/v4 refs from the stable v4 line\n\n## Verification\n- actionlint .github/workflows/release-new-version.yml .github/workflows/release-verify.yml\n- git diff --check\n- pre-commit lint/format/dist