### PR TITLE
ci: use stable workflows for bump jobs

### DIFF
--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@v2
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@v2
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- move Admin bump major/minor reusable workflow callers from workflows v2.0-alpha to stable workflows v2

## Validation
- actionlint -color=false on all workflow files
- git diff --check
- residual scan for old workflow owners, alpha foundation refs, deprecated runtime markers, and old first-party action majors

Yarn lint/build was not used as evidence because the local checkout currently fails eslint config discovery before this workflow-only change is evaluated.